### PR TITLE
Add /positions command for IT job search in Netherlands

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from datetime import datetime
+import time
 
 import requests
 from bs4 import BeautifulSoup
@@ -107,3 +108,137 @@ def summ_with_groq(messages):
         model="llama3-8b-8192", messages=message, temperature=0
     )
     return response
+
+
+def scrape_linkedin_jobs():
+    """
+    Scrapes LinkedIn for IT jobs in The Netherlands.
+    Returns list of job dictionaries with title, company, location, and link.
+    Note: LinkedIn actively blocks scrapers - this may need regular maintenance.
+    """
+    
+    # IT-related keywords for filtering
+    it_keywords = [
+        'software engineer', 'software developer', 'python developer', 'java developer',
+        'javascript developer', 'react developer', 'frontend developer', 'backend developer',
+        'full stack developer', 'web developer', 'mobile developer', 'ios developer',
+        'android developer', 'devops engineer', 'system administrator', 'data scientist',
+        'data analyst', 'machine learning engineer', 'product designer', 'ui designer',
+        'ux designer', 'product manager', 'technical lead', 'engineering manager',
+        'qa engineer', 'test engineer', 'cybersecurity', 'cloud engineer', 'architect'
+    ]
+    
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Encoding': 'gzip, deflate',
+        'Connection': 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+    }
+    
+    try:
+        # LinkedIn job search URL for Netherlands with IT keywords
+        # Using multiple searches to increase IT job results
+        search_terms = [
+            "software%20engineer",
+            "software%20developer", 
+            "frontend%20developer",
+            "backend%20developer",
+            "python%20developer",
+            "javascript%20developer"
+        ]
+        
+        all_jobs = []
+        
+        for term in search_terms[:2]:  # Use first 2 terms to avoid too many requests
+            url = f"https://www.linkedin.com/jobs/search/?keywords={term}&location=Netherlands&sortBy=DD"
+            
+            logger.info(f"Searching LinkedIn for: {term.replace('%20', ' ')}")
+            
+            try:
+                response = requests.get(url, headers=headers, timeout=10)
+                
+                if response.status_code == 200:
+                    soup = BeautifulSoup(response.content, 'html.parser')
+                    
+                    # Look for job cards (LinkedIn's structure may change)
+                    job_cards = soup.find_all('div', class_='base-card')
+                    if not job_cards:
+                        job_cards = soup.find_all('div', {'data-entity-urn': True})
+                    
+                    for card in job_cards[:15]:  # Process first 15 jobs from each search
+                        try:
+                            # Extract job title
+                            title_elem = card.find('h3') or card.find('a', class_='base-card__full-link')
+                            title = title_elem.get_text(strip=True) if title_elem else "Unknown Title"
+                            
+                            # Extract company name
+                            company_elem = card.find('a', class_='hidden-nested-link') or card.find('h4')
+                            company = company_elem.get_text(strip=True) if company_elem else "Unknown Company"
+                            
+                            # Extract location
+                            location_elem = card.find('span', class_='job-search-card__location')
+                            location = location_elem.get_text(strip=True) if location_elem else "Netherlands"
+                            
+                            # Extract job link
+                            link_elem = card.find('a', class_='base-card__full-link')
+                            link = link_elem.get('href') if link_elem else "#"
+                            
+                            # Since we're searching with IT terms, most results should be IT-related
+                            # But still filter to be sure
+                            title_lower = title.lower()
+                            if any(keyword in title_lower for keyword in it_keywords):
+                                job_data = {
+                                    'title': title,
+                                    'company': company,
+                                    'location': location,
+                                    'link': f"https://linkedin.com{link}" if link.startswith('/') else link
+                                }
+                                
+                                # Avoid duplicates by checking if job already exists
+                                if not any(j['title'] == title and j['company'] == company for j in all_jobs):
+                                    all_jobs.append(job_data)
+                                    
+                        except Exception as e:
+                            logger.warning(f"Error parsing job card: {e}")
+                            continue
+                        
+                elif response.status_code == 429:
+                    logger.warning("LinkedIn rate limiting detected (429)")
+                    break  # Stop searching if rate limited
+                else:
+                    logger.warning(f"LinkedIn returned status code: {response.status_code} for term: {term}")
+                
+                # Add small delay between requests to be polite
+                time.sleep(1)
+                    
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Request failed for {term}: {e}")
+                continue
+        
+        # Sort by relevance and limit to 10
+        jobs = all_jobs[:10]
+        logger.info(f"Successfully scraped {len(jobs)} IT jobs from LinkedIn")
+        return jobs
+        
+    except Exception as e:
+        logger.error(f"Unexpected error during LinkedIn scraping: {e}")
+        return []
+
+
+def format_jobs_message(jobs):
+    """Format job list into a readable Telegram message."""
+    if not jobs:
+        return "🔍 Sorry, no IT jobs found in The Netherlands at the moment. LinkedIn might be blocking requests or there are no new postings."
+    
+    message = "🇳🇱 **Latest IT Jobs in The Netherlands:**\n\n"
+    
+    for i, job in enumerate(jobs, 1):
+        message += f"**{i}. {job['title']}**\n"
+        message += f"🏢 {job['company']}\n"
+        message += f"📍 {job['location']}\n"
+        message += f"🔗 [Apply here]({job['link']})\n\n"
+    
+    message += "⚠️ *Note: LinkedIn actively blocks scrapers. If no jobs appear, try again later.*"
+    return message

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from threading import Timer
 import telebot
 
 from api import (find_url, read_url, send_conversation, summ_with_groq,
-                 writing_message)
+                 writing_message, scrape_linkedin_jobs, format_jobs_message)
 from config import logger, settings
 from db import DataBase
 from health_endpoint import flask_thread, shutdown_event
@@ -21,6 +21,7 @@ bot.set_my_commands(
     [
         telebot.types.BotCommand("/read_link", "Что там за ссылкой?"),
         telebot.types.BotCommand("/house_points", "Баллы факультетов"),
+        telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
     ]
 )
 
@@ -29,6 +30,7 @@ bot.set_my_commands(
         telebot.types.BotCommand("/read_link", "Что там за ссылкой?"),
         telebot.types.BotCommand("/show_logs", "Показать логи"),
         telebot.types.BotCommand("/house_points", "Баллы факультетов"),
+        telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
     ],
     scope=telebot.types.BotCommandScopeChat(INSPECT_ID),
 )
@@ -39,6 +41,7 @@ if not settings.DEBUG:
             commands=[
                 telebot.types.BotCommand("/read_link", "Что там за ссылкой?"),
                 telebot.types.BotCommand("/house_points", "Баллы факультетов"),
+                telebot.types.BotCommand("/positions", "IT jobs in Netherlands"),
             ],
             scope=telebot.types.BotCommandScopeChat(ADMIN_ID),
         )
@@ -118,6 +121,28 @@ def show_stat(message):
         answer_stat = read_records()
         return bot.send_message(
             message.chat.id, answer_stat, parse_mode="Markdown"
+        )
+
+
+@bot.message_handler(commands=["positions"])
+def get_positions(message):
+    """Scrapes and shows latest IT job positions in The Netherlands."""
+    bot.send_message(
+        message.chat.id,
+        "🔍 Searching for IT jobs in The Netherlands... This may take a moment.",
+        parse_mode="Markdown"
+    )
+    
+    try:
+        jobs = scrape_linkedin_jobs()
+        jobs_message = format_jobs_message(jobs)
+        bot.send_message(message.chat.id, jobs_message, parse_mode="Markdown")
+    except Exception as e:
+        logger.error(f"Error in positions command: {e}")
+        bot.send_message(
+            message.chat.id,
+            "❌ Sorry, there was an error fetching job positions. Please try again later.",
+            parse_mode="Markdown"
         )
 
 


### PR DESCRIPTION
- Scrapes LinkedIn for IT jobs using targeted search terms
- Searches for 'software engineer' and 'software developer'
- Filters results for 30+ IT-related job titles
- Returns up to 10 unique job listings with company, location, and links
- Includes duplicate detection and error handling
- Added command to all bot menus (general, admin, inspector)
- Gracefully handles LinkedIn rate limiting and blocking